### PR TITLE
fix: update alias from aip to gitaip in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -62,12 +62,12 @@ echo "$KEYCHAIN_SNIPPET" >> "$SHELL_CONFIG"
 echo "OPENAI_API_KEY registered in $SHELL_CONFIG."
 
 # Check if alias is already present
-if grep -q "alias aip=" "$SHELL_CONFIG"; then
-  echo "Existing 'aip' alias found in $SHELL_CONFIG."
+if grep -q "alias gitaip=" "$SHELL_CONFIG"; then
+  echo "Existing 'gitaip' alias found in $SHELL_CONFIG."
   read -p "Do you want to update it? [y/N] " choice
   case "$choice" in
     y|Y )
-      sed -i.bak "/alias aip=/d" "$SHELL_CONFIG"
+      sed -i.bak "/alias gitaip=/d" "$SHELL_CONFIG"
       ;;
     * )
       echo "Leaving existing alias unchanged."
@@ -77,8 +77,8 @@ if grep -q "alias aip=" "$SHELL_CONFIG"; then
 fi
 
 # Register alias
-echo "alias aip='bash $(pwd)/$AIP_SCRIPT'" >> "$SHELL_CONFIG"
-echo "aip alias registered in $SHELL_CONFIG."
+echo "alias gitaip='bash $(pwd)/$AIP_SCRIPT'" >> "$SHELL_CONFIG"
+echo "gitaip alias registered in $SHELL_CONFIG."
 
 # Advise to reload shell
 echo "To apply changes, run:"


### PR DESCRIPTION
### What Changed
This pull request updates the alias name in the `start.sh` script from `aip` to `gitaip`. The change ensures consistency with the intended naming conventions and avoids potential conflicts with existing aliases.

### Why
The previous alias, `aip`, could lead to conflicts or confusion if other scripts or tools use the same alias. By changing it to `gitaip`, we aim to provide a more descriptive and unique alias that reflects its purpose related to git operations.

### Additional Notes
- The script now checks for the `gitaip` alias instead of `aip`.
- Users are prompted to update the alias if it already exists.
- The registration message has been updated to reflect the new alias name.