### PR TITLE
fix: improve awk parsing for branch and commit message extraction

### DIFF
--- a/git_commands/gitaip.sh
+++ b/git_commands/gitaip.sh
@@ -160,8 +160,21 @@ EOF
 
   OUTPUT=$(echo "$HTTP_BODY" | jq -r '.choices[0].message.content // empty')
 
-  BRANCH=$(echo "$OUTPUT" | awk '/^[Bb]ranch name:/ { getline; print; exit }' | xargs)
-  MESSAGE=$(echo "$OUTPUT" | awk '/^[Cc]ommit message:/ { getline; print; exit }' | xargs)
+  # Get branch name
+  BRANCH=$(echo "$OUTPUT" | awk '
+    /^[Bb]ranch name:/ {
+      match($0, /^[Bb]ranch name:[[:space:]]*(.*)/, m);
+      if (m[1] != "") { print m[1]; exit }
+      else { getline; print; exit }
+    }' | xargs)
+
+  # Get commit message
+  MESSAGE=$(echo "$OUTPUT" | awk '
+    /^[Cc]ommit message:/ {
+      match($0, /^[Cc]ommit message:[[:space:]]*(.*)/, m);
+      if (m[1] != "") { print m[1]; exit }
+      else { getline; print; exit }
+    }' | xargs)
   BODY=$(echo "$OUTPUT" | awk '/^[Pp][Rr] [Bb]ody:/ {flag=1; next} flag')
 
   if [[ -z "$BRANCH" || -z "$MESSAGE" ]]; then


### PR DESCRIPTION
This pull request improves the parsing logic in `gitaip.sh` for extracting branch names and commit messages. The previous implementation had a potential issue where it might not correctly handle cases where the branch name or commit message is provided on the same line as their respective labels. The updated logic uses `awk` with regular expressions to handle both inline and subsequent line formats, ensuring more robust parsing. This change enhances the reliability of the script when processing output from the AI tool.